### PR TITLE
Modified FluidConstant

### DIFF
--- a/src/main/java/frc/robot/config/FluidConstant.java
+++ b/src/main/java/frc/robot/config/FluidConstant.java
@@ -92,8 +92,9 @@ public class FluidConstant<T> implements Supplier<T> {
      */
     public void setValue(T newValue) {
         // Send the update to all the registered actions
-        this.updateActions.forEach(a -> a.accept(this.value, newValue));
+        T oldValue = this.value;
         this.value = newValue;
+        this.updateActions.forEach(a -> a.accept(oldValue, newValue));
     }
 
     /**


### PR DESCRIPTION
Made another very small change to FluidConstant. This could have repercussions if used with old code but not likely.

I wanted to make sure that if a listener gets activated that it is able to call the get() method and get the most recent value. To do that I needed to change around the order in which things happened in the setValue.

Basically I needed this.Value = newValue; to happen before the updateActions.